### PR TITLE
Fix ssh_keys template 'group cannot be determined' error

### DIFF
--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -118,11 +118,23 @@ action :create do
         end
 
         if u['ssh_keys']
+  		  #on suse, i had errors if group didn't exist with the ssh_keys template, so try creating first
+		  case node['platform_family']
+      	    when 'suse'
+			  group new_resource.group_name do
+    			gid new_resource.group_id
+    			action :create
+			  end
+      	  end
           template "#{home_dir}/.ssh/authorized_keys" do
             source "authorized_keys.erb"
             cookbook new_resource.cookbook
             owner u['username']
-            group u['gid'] || u['username']
+			if node['platform_family'] == 'suse' 
+			  group new_resource.group_name
+			else 
+              group u['gid'] || u['username']
+			end
             mode "0600"
             variables :ssh_keys => u['ssh_keys']
           end

--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -118,23 +118,23 @@ action :create do
         end
 
         if u['ssh_keys']
-  		  #on suse, i had errors if group didn't exist with the ssh_keys template, so try creating first
-		  case node['platform_family']
-      	    when 'suse'
-			  group new_resource.group_name do
-    			gid new_resource.group_id
-    			action :create
-			  end
-      	  end
+          #on suse, i had errors if group didn't exist with the ssh_keys template, so try creating first
+          case node['platform_family']
+          when 'suse'
+            group new_resource.group_name do
+              gid new_resource.group_id
+              action :create
+            end
+          end
           template "#{home_dir}/.ssh/authorized_keys" do
             source "authorized_keys.erb"
             cookbook new_resource.cookbook
             owner u['username']
-			if node['platform_family'] == 'suse' 
-			  group new_resource.group_name
-			else 
+            if node['platform_family'] == 'suse' 
+              group new_resource.group_name
+            else 
               group u['gid'] || u['username']
-			end
+            end
             mode "0600"
             variables :ssh_keys => u['ssh_keys']
           end


### PR DESCRIPTION
As discussed on https://github.com/opscode-cookbooks/users/issues/64 , I had some trouble using the 'ssh_keys' attribute when using the users cookbook...

When my user.json did NOT include a 'gid' attribute, I was getting an error:
```
template[/home/giorgos/.ssh/authorized_keys] (/tmp/vagrant-chef-3/chef-solo-1/cookbooks/users/providers/manage.rb line 121) had an error: Chef::Exceptions::GroupIDNotFound: cannot determine group id for 'giorgos', does the group exist on this system?
```
(https://github.com/opscode-cookbooks/users/blob/master/providers/manage.rb#L121)

The template resource was not able to find the group id...
So, I tried including a 'gid' attribute, only this time:
```
==> default: Chef::Exceptions::User
==> default: ----------------------
==> default: user[giorgos] (/tmp/vagrant-chef-3/chef-solo-1/cookbooks/users/providers/manage.rb line 94) had an error: Chef::Exceptions::User: Couldn't lookup integer GID for group name 7000
```
...leaving me no choice but to change the source code...
(This is all on an OpenSUSE 13.1 VM, so it might work on other OS)