### PR TITLE
Fix unit tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
+  - 2.2
 
 bundler_args: --jobs 7
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 group :testing do
-  gem 'chefspec',  '~> 3.4'
-  gem 'berkshelf', '~> 3.0.0.beta7'
+  gem 'chefspec'
+  gem 'berkshelf'
 end
 
 gem 'rake'

--- a/spec/recipes/home_dir_spec.rb
+++ b/spec/recipes/home_dir_spec.rb
@@ -5,15 +5,15 @@ describe 'users_test::test_home_dir' do
   let(:stat_nfs) { double('stat_nfs') }
 
   before do
-    stat.stub(:run_command).and_return(stat)
-    stat.stub(:stdout).and_return('none')
+    allow(stat).to receive(:run_command).and_return(stat)
+    allow(stat).to receive(:stdout).and_return('none')
 
-    stat_nfs.stub(:run_command).and_return(stat_nfs)
-    stat_nfs.stub(:stdout).and_return('nfs')
+    allow(stat_nfs).to receive(:run_command).and_return(stat_nfs)
+    allow(stat_nfs).to receive(:stdout).and_return('nfs')
 
-    Mixlib::ShellOut.stub(:new).with('stat -f -L -c %T /home/user_with_local_home 2>&1').and_return(stat)
-    Mixlib::ShellOut.stub(:new).with('stat -f -L -c %T /home/user_with_nfs_home_first 2>&1').and_return(stat_nfs)
-    Mixlib::ShellOut.stub(:new).with('stat -f -L -c %T /home/user_with_nfs_home_second 2>&1').and_return(stat_nfs)
+    allow(Mixlib::ShellOut).to receive(:new).with('stat -f -L -c %T /home/user_with_local_home 2>&1').and_return(stat)
+    allow(Mixlib::ShellOut).to receive(:new).with('stat -f -L -c %T /home/user_with_nfs_home_first 2>&1').and_return(stat_nfs)
+    allow(Mixlib::ShellOut).to receive(:new).with('stat -f -L -c %T /home/user_with_nfs_home_second 2>&1').and_return(stat_nfs)
   end
 
   cached(:chef_run) do

--- a/spec/recipes/home_dir_spec.rb
+++ b/spec/recipes/home_dir_spec.rb
@@ -5,26 +5,6 @@ describe 'users_test::test_home_dir' do
   let(:stat_nfs) { double('stat_nfs') }
 
   before do
-    ChefSpec::Server.create_data_bag('test_home_dir', {
-      user_with_dev_null_home: {
-        id: 'user_with_dev_null_home',
-        groups: ['testgroup'],
-        home: '/dev/null',
-      },
-      user_with_nfs_home_first: {
-        id: 'user_with_nfs_home_first',
-        groups: ['testgroup'],
-      },
-      user_with_nfs_home_second: {
-        id: 'user_with_nfs_home_second',
-        groups: ['nfsgroup'],
-      },
-      user_with_local_home: {
-        id: 'user_with_local_home',
-        groups: ['testgroup'],
-      },
-    })
-
     stat.stub(:run_command).and_return(stat)
     stat.stub(:stdout).and_return('none')
 
@@ -36,13 +16,32 @@ describe 'users_test::test_home_dir' do
     Mixlib::ShellOut.stub(:new).with('stat -f -L -c %T /home/user_with_nfs_home_second 2>&1').and_return(stat_nfs)
   end
 
-
   cached(:chef_run) do
-    ChefSpec::Runner.new(
+    ChefSpec::ServerRunner.new(
       step_into: ['users_manage'],
       platform: 'ubuntu',
       version: '12.04'
-    ).converge(described_recipe)
+    ) do |node, server|
+      server.create_data_bag('test_home_dir', {
+        user_with_dev_null_home: {
+          id: 'user_with_dev_null_home',
+          groups: ['testgroup'],
+          home: '/dev/null',
+        },
+        user_with_nfs_home_first: {
+          id: 'user_with_nfs_home_first',
+          groups: ['testgroup'],
+        },
+        user_with_nfs_home_second: {
+          id: 'user_with_nfs_home_second',
+          groups: ['nfsgroup'],
+        },
+        user_with_local_home: {
+          id: 'user_with_local_home',
+          groups: ['testgroup'],
+        },
+      })
+    end.converge(described_recipe)
   end
 
   context 'Resource "users_manage"' do

--- a/spec/recipes/sysadmins_spec.rb
+++ b/spec/recipes/sysadmins_spec.rb
@@ -1,8 +1,14 @@
 require 'spec_helper'
 
 describe 'users::sysadmins' do
-  before do
-    ChefSpec::Server.create_data_bag('users', {
+
+  cached(:chef_run) do
+    ChefSpec::ServerRunner.new(
+      step_into: ['users_manage'],
+      platform: 'ubuntu',
+      version: '12.04'
+    ) do |node, server|
+     server.create_data_bag('users', {
       createme: {
         id: 'createme',
         groups: ['sysadmin'],
@@ -29,14 +35,7 @@ describe 'users::sysadmins' do
         groups: ['nonadmin'],
       },
     })
-  end
-
-  cached(:chef_run) do
-    ChefSpec::Runner.new(
-      step_into: ['users_manage'],
-      platform: 'ubuntu',
-      version: '12.04'
-    ).converge(described_recipe)
+    end.converge(described_recipe)
   end
 
   context 'Resource "users_manage"' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 require 'chefspec/cacher'
-require 'chefspec/server'
 
 RSpec.configure do |config|
   config.log_level = :warn


### PR DESCRIPTION
There's still one deprecation warning that I don't know how to fix... maybe @someara knows how to fix this:

```
Deprecation Warnings:

Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /Users/juliandunn/devel/gh/juliandunn/users/spec/recipes/home_dir_spec.rb:8:in `block (2 levels) in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

1 deprecation warning total```