### PR TITLE
Support Chef < 12

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,8 +5,8 @@ license          "Apache 2.0"
 description      "Creates users from a databag search"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "1.8.3"
-source_url       "https://github.com/opscode-cookbooks/users"
-issues_url       "https://github.com/opscode-cookbooks/users/issues"
+source_url       "https://github.com/opscode-cookbooks/users" if respond_to?(:source_url)
+issues_url       "https://github.com/opscode-cookbooks/users/issues" if respond_to?(:issues_url)
 recipe           "users", "Empty recipe for including LWRPs"
 recipe           "users::sysadmins", "Create and manage sysadmin group"
 


### PR DESCRIPTION
source_url and issues_url are Chef 12 attributes that do not have backwards compatibility, so only set them if running with a version of Chef that supports them.

Addresses PR #98 .

(many occurrences of this all over - e.g. see https://github.com/logentries/le_chef/pull/30 )
